### PR TITLE
Update Format-category.md to include slug in category keys

### DIFF
--- a/Format-category.md
+++ b/Format-category.md
@@ -32,6 +32,7 @@ This is just a category name.
 ```json
     "url_key": "hoodies-and-sweatshirts-24",
     "url_path": "women/tops-women/hoodies-and-sweatshirts-women/hoodies-and-sweatshirts-24",
+    "slug": "hoodies-and-sweatshirts-24"
 ```
 
 ```json


### PR DESCRIPTION
slug is needed for POST queries support in ES, otherwise causing the empty page to load, adding to the category keys needed as described on 
https://github.com/DivanteLtd/vue-storefront-api/blob/master/config/elastic.schema.category.json#L5